### PR TITLE
Timeedit general.id and general.title fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 ssl.crt
 ssl.key
 platforms.json
+.env

--- a/src/components/AsyncSelect.js
+++ b/src/components/AsyncSelect.js
@@ -53,18 +53,29 @@ class AsyncSelect extends React.Component {
             ),
             json => {
                 this.setState({
-                    options: json.map(x => ({
-                        id: x.extid,
-                        label:
-                            x["general.id"] +
-                            (x.hasOwnProperty("general.title")
-                                ? ` | ${x["general.title"]}`
-                                : "")
+                    options: json.map(objectToMap => ({
+                        id: objectToMap.extid,
+                        label: this.createField(objectToMap, "id") +
+                            this.createField(objectToMap, "title")
                     })),
                     isLoading: false
                 });
             }
         );
+    }
+
+    /**
+     * This function is needed since RKH use _ref suffix for id and title.
+     */
+    createField(objectToCreateFrom, type) {
+        let fieldToReturn = "";
+        if (objectToCreateFrom.hasOwnProperty('general.' + type)) {
+            fieldToReturn = objectToCreateFrom['general.' + type]
+        }
+        if (objectToCreateFrom.hasOwnProperty('general.' + type + '_ref')) {
+            fieldToReturn = objectToCreateFrom['general.' + type + '_ref']
+        }
+        return fieldToReturn
     }
 
     getOptionById(queryId) {

--- a/src/components/Sync.js
+++ b/src/components/Sync.js
@@ -73,8 +73,8 @@ class Sync extends React.Component {
                             .then(data => ({
                                 extid: data.extid,
                                 type: c.te_type, // TODO: Convert this to a type name using /api/timeedit/types
-                                id: data["general.id"],
-                                title: data["general.title"]
+                                id: this.createField(data, "id"),
+                                title: this.createField(data, "title")
                             }))
                             .catch(e => {
                                 // This will lead Promise.all to also reject at
@@ -92,6 +92,20 @@ class Sync extends React.Component {
                 });
             })
             .catch(e => console.error(e)); // (2)
+    }
+
+    /**
+     * This function is needed since RKH use _ref suffix for id and title.
+     */
+    createField(objectToCreateFrom, type) {
+        let fieldToReturn = "";
+        if (objectToCreateFrom.hasOwnProperty('general.' + type)) {
+            fieldToReturn = objectToCreateFrom['general.' + type]
+        }
+        if (objectToCreateFrom.hasOwnProperty('general.' + type + '_ref')) {
+            fieldToReturn = objectToCreateFrom['general.' + type + '_ref']
+        }
+        return fieldToReturn
     }
 
     feedback(message) {


### PR DESCRIPTION
This is needed since some timeedit instances use general.id_ref and general.title_ref instead of just general.id and general.title