### PR TITLE
feat: interactive template config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ssl.crt
 ssl.key
 platforms.json
 .env
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "te-canvas-front",
-    "version": "1.1.1",
+    "version": "1.1.0",
     "description": "",
     "scripts": {
         "start": "API_URL=$LTI_URL ./make-inject-env.sh && DEBUG=provider:* node src/lti.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "te-canvas-front",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "",
     "scripts": {
         "start": "API_URL=$LTI_URL ./make-inject-env.sh && DEBUG=provider:* node src/lti.js",
@@ -30,6 +30,7 @@
     },
     "prettier": {
         "tabWidth": 4,
+        "semi": true,
         "trailingComma": "none",
         "arrowParens": "avoid",
         "importOrder": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "te-canvas-front",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "",
     "scripts": {
         "start": "API_URL=$LTI_URL ./make-inject-env.sh && DEBUG=provider:* node src/lti.js",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -66,32 +66,32 @@ class TemplateErrorFeedback extends React.Component {
 
     componentDidMount() {
         this.refresh();
-        this.interval = setInterval(this.refresh, 1000);
+        // this.interval = setInterval(this.refresh, 1000);
     }
 
     componentWillUnmount() {
-        clearInterval(this.interval);
+        // clearInterval(this.interval);
     }
 
     refresh() {
-        fetch(urlParams(window.injectedEnv.API_URL, "/api/config/ok", {}))
-            .then(resp => {
-                if (resp.status !== 200)
-                    throw new Error(
-                        `Unexpected HTTP response from /api/config/ok: ${resp.status}`
-                    );
-                return resp.text();
-            })
-            .then(text => {
-                if (text === "True") this.setState({ templateError: false });
-                else if (text === "False")
-                    this.setState({ templateError: true });
-                else
-                    throw new Error(
-                        `Unexpected text response from /api/config/ok: ${text}`
-                    );
-            })
-            .catch(e => console.error(e));
+        // fetch(urlParams(window.injectedEnv.API_URL, "/api/config/ok", {}))
+        //     .then(resp => {
+        //         if (resp.status !== 200)
+        //             throw new Error(
+        //                 `Unexpected HTTP response from /api/config/ok: ${resp.status}`
+        //             );
+        //         return resp.text();
+        //     })
+        //     .then(text => {
+        //         if (text === "True") this.setState({ templateError: false });
+        //         else if (text === "False")
+        //             this.setState({ templateError: true });
+        //         else
+        //             throw new Error(
+        //                 `Unexpected text response from /api/config/ok: ${text}`
+        //             );
+        //     })
+        //     .catch(e => console.error(e));
     }
 
     render() {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,10 +3,9 @@ import React from "react";
 import { Heading, InstUISettingsProvider, Tabs, canvas } from "@instructure/ui";
 
 import "../style.css";
-
-import { urlParams } from "../util";
+// import { urlParams } from "../util";
 import Config from "./Config";
-import Feedback from "./Feedback";
+// import Feedback from "./Feedback";
 import Sync from "./Sync";
 
 class App extends React.Component {
@@ -46,15 +45,17 @@ class App extends React.Component {
                             <Config />
                         </Tabs.Panel>
                     </Tabs>
-                    <TemplateErrorFeedback />
                 </div>
             </InstUISettingsProvider>
         );
     }
 }
 
-// Check `/config/ok` at an interval of 1 second and display a warning message
-// if the template config is incomplete.
+// TODO: reimplement template config check in frontend
+
+/**
+Check `/config/ok` at an interval of 1 second and display a warning message
+if the template config is incomplete.
 class TemplateErrorFeedback extends React.Component {
     constructor(props) {
         super(props);
@@ -74,33 +75,34 @@ class TemplateErrorFeedback extends React.Component {
     }
 
     refresh() {
-        // fetch(urlParams(window.injectedEnv.API_URL, "/api/config/ok", {}))
-        //     .then(resp => {
-        //         if (resp.status !== 200)
-        //             throw new Error(
-        //                 `Unexpected HTTP response from /api/config/ok: ${resp.status}`
-        //             );
-        //         return resp.text();
-        //     })
-        //     .then(text => {
-        //         if (text === "True") this.setState({ templateError: false });
-        //         else if (text === "False")
-        //             this.setState({ templateError: true });
-        //         else
-        //             throw new Error(
-        //                 `Unexpected text response from /api/config/ok: ${text}`
-        //             );
-        //     })
-        //     .catch(e => console.error(e));
-    }
-
-    render() {
-        return (
-            this.state.templateError && (
-                <Feedback message="Syncing is suspended due to incomplete Event Template." />
-            )
-        );
-    }
+fetch(urlParams(window.injectedEnv.API_URL, "/api/config/ok", {}))
+    .then(resp => {
+        if (resp.status !== 200)
+            throw new Error(
+                `Unexpected HTTP response from /api/config/ok: ${resp.status}`
+            );
+        return resp.text();
+    })
+    .then(text => {
+        if (text === "True") this.setState({ templateError: false });
+        else if (text === "False")
+            this.setState({ templateError: true });
+        else
+            throw new Error(
+                `Unexpected text response from /api/config/ok: ${text}`
+            );
+    })
+    .catch(e => console.error(e));
 }
+
+render() {
+    return (
+        this.state.templateError && (
+            <Feedback message="Syncing is suspended due to incomplete Event Template." />
+        )
+    );
+}
+}
+**/
 
 export default App;

--- a/src/components/AsyncSelect.js
+++ b/src/components/AsyncSelect.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Select, Spinner } from "@instructure/ui";
 
-import { parseResponse, urlParams } from "../util";
+import { createField, parseResponse, urlParams } from "../util";
 
 let initState = {
     inputValue: "",
@@ -39,43 +39,26 @@ class AsyncSelect extends React.Component {
     refresh(search_string) {
         parseResponse(
             fetch(
-                urlParams(
-                    window.injectedEnv.API_URL,
-                    "/api/timeedit/objects",
-                    {
-                        type: this.props.type,
-                        number_of_objects: 10,
-                        ...(search_string === null
-                            ? {}
-                            : { search_string: search_string })
-                    }
-                )
+                urlParams(window.injectedEnv.API_URL, "/api/timeedit/objects", {
+                    type: this.props.type,
+                    number_of_objects: 10,
+                    ...(search_string === null
+                        ? {}
+                        : { search_string: search_string })
+                })
             ),
             json => {
                 this.setState({
                     options: json.map(objectToMap => ({
                         id: objectToMap.extid,
-                        label: this.createField(objectToMap, "id") +
-                            this.createField(objectToMap, "title")
+                        label:
+                            createField(objectToMap, "id") +
+                            createField(objectToMap, "title")
                     })),
                     isLoading: false
                 });
             }
         );
-    }
-
-    /**
-     * This function is needed since RKH use _ref suffix for id and title.
-     */
-    createField(objectToCreateFrom, type) {
-        let fieldToReturn = "";
-        if (objectToCreateFrom.hasOwnProperty('general.' + type)) {
-            fieldToReturn = objectToCreateFrom['general.' + type]
-        }
-        if (objectToCreateFrom.hasOwnProperty('general.' + type + '_ref')) {
-            fieldToReturn = objectToCreateFrom['general.' + type + '_ref']
-        }
-        return fieldToReturn
     }
 
     getOptionById(queryId) {

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Button, Heading, IconPlusLine, SimpleSelect, TextArea, TextInput, View } from "@instructure/ui";
+import { Button, Heading, IconPlusLine, IconTrashLine, SimpleSelect, TextArea, TextInput, View } from "@instructure/ui";
 
 import { urlParams } from "../util";
 
@@ -12,10 +12,7 @@ class Config extends React.Component {
              location: [],
              description: []
         };
-
         this.refresh = this.refresh.bind(this);
-        this.handleChange = this.handleChange.bind(this);
-        this.submit = this.submit.bind(this);
     }
 
     componentDidMount() {
@@ -37,27 +34,18 @@ class Config extends React.Component {
             )
     }
 
-    submit() {
-        // for (let k of ["title", "location", "description"]) {
-        //     fetch(
-        //         urlParams(window.injectedEnv.API_URL, "/api/config", {
-        //             key: k,
-        //             value: this.state[k]
-        //         }),
-        //         {
-        //             method: "PUT"
-        //         }
-        //     ).then(resp => {
-        //         if (resp.status !== 200)
-        //             throw new Error(
-        //                 `Unexpected HTTP response from backend: ${resp.status}`
-        //             );
-        //     });
-        // }
-    }
-
-    handleChange(k, v) {
-        // this.setState({ [k]: v });
+    handleDelete(id) {
+        console.log("delete",id)
+        fetch(urlParams(window.injectedEnv.API_URL, "/api/config/template",{ id: id }),
+        { method: "DELETE"}).then(resp => {
+            if (resp.status !== 204)
+                throw new Error(`Unexpected HTTP response from backend: ${resp.status}`)
+            this.setState({
+                title: this.state.title.filter(n => n.id !== id),
+                location: this.state.location.filter(n => n.id !== id),
+                description: this.state.description.filter(n => n.id !== id),
+            })
+        })
     }
 
     render() {
@@ -79,7 +67,11 @@ class Config extends React.Component {
             >
                 Add title field
             </Button>
-            {this.state.title && this.state.title.map(r => r.te_type)}
+            {this.state.title && this.state.title.map(r => 
+                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
+                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
+                </Button>
+                )}
                 </View>
                 <Heading level="h2">Location</Heading>
                 <View
@@ -97,7 +89,11 @@ class Config extends React.Component {
             >
                 Add location field
             </Button>
-            {this.state.location && this.state.location.map(r => r.te_type)}
+            {this.state.location && this.state.location.map(r =>
+                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
+                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
+                </Button>
+                )}
                 </View>
                 <Heading level="h2">Description</Heading>
 
@@ -116,11 +112,12 @@ class Config extends React.Component {
             >
                 Add description field
             </Button>
-            {this.state.description && this.state.description.map(r => r.te_type)}
+            {this.state.description && this.state.description.map(r => 
+                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
+                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
+                </Button>
+            )}
                 </View>
-                <Button onClick={this.submit}>Save and apply</Button>
-                &nbsp;
-                <Button onClick={this.refresh}>Discard edits</Button>
             </div>
         );
     }

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,6 +1,16 @@
 import React from "react";
 
-import { Button, Grid, GridCol, Heading, IconPlusLine, IconTrashLine, Modal, SimpleSelect, Tag, TextArea, TextInput, View } from "@instructure/ui";
+import {
+    Button,
+    Grid,
+    Heading,
+    IconPlusLine,
+    IconTrashLine,
+    Select,
+    SimpleSelect,
+    Spinner,
+    View
+} from "@instructure/ui";
 
 import { parseResponse, urlParams } from "../util";
 
@@ -8,44 +18,42 @@ class Config extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-             title: [],
-             location: [],
-             description: []
+            title: [],
+            location: [],
+            description: []
         };
-        this.refresh = this.refresh.bind(this);
         this.handleDelete = this.handleDelete.bind(this);
     }
 
     componentDidMount() {
-        this.refresh();
-    }
-
-    refresh() {
-            fetch(
-                urlParams(window.injectedEnv.API_URL, "/api/config/template")
-            )
-                .then(resp => {
-                    if (resp.status !== 200)
-                        throw new Error(
-                            `Unexpected HTTP response from backend: ${resp.status}`
-                        );
-                    return resp.json()
-                })
-                .then(data => this.setState(data)
-            )
+        fetch(urlParams(window.injectedEnv.API_URL, "/api/config/template"))
+            .then(resp => {
+                if (resp.status !== 200)
+                    throw new Error(
+                        `Unexpected HTTP response from backend: ${resp.status}`
+                    );
+                return resp.json();
+            })
+            .then(data => this.setState(data));
     }
 
     handleDelete(id) {
-        fetch(urlParams(window.injectedEnv.API_URL, "/api/config/template",{ id: id }),
-        { method: "DELETE"}).then(resp => {
+        fetch(
+            urlParams(window.injectedEnv.API_URL, "/api/config/template", {
+                id: id
+            }),
+            { method: "DELETE" }
+        ).then(resp => {
             if (resp.status !== 204)
-                throw new Error(`Unexpected HTTP response from backend: ${resp.status}`)
+                throw new Error(
+                    `Unexpected HTTP response from backend: ${resp.status}`
+                );
             this.setState({
                 title: this.state.title.filter(n => n.id !== id),
                 location: this.state.location.filter(n => n.id !== id),
-                description: this.state.description.filter(n => n.id !== id),
-            })
-        })
+                description: this.state.description.filter(n => n.id !== id)
+            });
+        });
     }
 
     render() {
@@ -60,12 +68,12 @@ class Config extends React.Component {
                     name="location"
                     children={this.state.location}
                     onDelete={this.handleDelete}
-                    />
+                />
                 <ConfigSection
                     name="description"
                     children={this.state.description}
                     onDelete={this.handleDelete}
-                />    
+                />
             </div>
         );
     }
@@ -75,82 +83,84 @@ export default Config;
 
 class ConfigSection extends React.Component {
     constructor(props) {
-        super(props)
+        super(props);
         this.state = {
             addNew: false
-        }
+        };
+        this.handleCancel = this.handleCancel.bind(this);
+    }
+
+    handleCancel() {
+        this.setState({
+            addNew: false
+        });
     }
 
     render() {
         return (
-                <View
+            <View
                 display="block"
                 borderRadius="medium"
                 borderWidth="small"
                 background="secondary"
                 padding="medium"
                 margin="small"
-                >
-                    <Grid>
-                        <Grid.Row>
-                            <Grid.Col>
-                                <Heading level="h2">{this.props.name.charAt(0).toUpperCase()}{this.props.name.slice(1)}</Heading>
-                            </Grid.Col>
-                            <Grid.Col width="auto">
-                                <Button
-                                    renderIcon={IconPlusLine}
-                                    margin="small"
-                                    color="primary"
-                                    onClick={() => this.setState({ addNew: !this.state.addNew })}
-                                >
-                                    Add {this.props.name} field
-                                </Button>
-                            </Grid.Col>
-                        </Grid.Row>
-                        <Grid.Row>
-                            <AddNew 
-                                type={this.props.name}
-                                active={this.state.addNew} />
-                        </Grid.Row>
-            {this.props.children && this.props.children.map(c => 
-                <Grid.Row>
-                    <Button
-                        key={c.id}
-                        onClick={() => this.props.onDelete(c.id)}
-                        renderIcon={IconTrashLine}>
-                        <strong>{c.te_type}</strong> - {c.te_fields.join('.')}
-                    </Button>
-                </Grid.Row>
+            >
+                <Heading level="h2">
+                    {this.props.name.charAt(0).toUpperCase()}
+                    {this.props.name.slice(1)}
+                </Heading>
+                <div>
+                    {!this.state.addNew && (
+                        <Button
+                            renderIcon={IconPlusLine}
+                            margin="small"
+                            color="primary"
+                            onClick={() =>
+                                this.setState({
+                                    addNew: !this.state.addNew
+                                })
+                            }
+                        >
+                            Add {this.props.name} field
+                        </Button>
+                    )}
+                </div>
+                {this.state.addNew && (
+                    <AddNewField
+                        name={this.props.name}
+                        onCancel={this.handleCancel}
+                    />
                 )}
-                    </Grid>
-                </View>
-
-    )}
-}
-
-class AddNew extends React.Component {
-    constructor(props) {
-        super(props)
-    }
-
-    render() {
-        return (
-            <div>
-            {this.props.active && <AddNewForm />}
-            </div>
-        )
+                {this.props.children &&
+                    this.props.children.map(c => (
+                        <div key={c.id} style={{ marginBottom: 10 }}>
+                            <Button
+                                onClick={() => this.props.onDelete(c.id)}
+                                renderIcon={IconTrashLine}
+                            >
+                                <strong>{c.te_type}</strong>-{c.te_field}
+                            </Button>
+                        </div>
+                    ))}
+            </View>
+        );
     }
 }
 
-class AddNewForm extends React.Component {
+class AddNewField extends React.Component {
     constructor(props) {
-        super(props)
+        super(props);
 
         this.state = {
-            types: []
-        }
+            types: [],
+            type: null,
+            isLoading: true
+        };
+        this.handleSelect = this.handleSelect.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
     }
-    
+
     componentDidMount() {
         let promise = fetch(
             urlParams(window.injectedEnv.API_URL, "/api/timeedit/types", {})
@@ -161,36 +171,246 @@ class AddNewForm extends React.Component {
                     extid: k,
                     title: v
                 })),
-                // If the types include "courseevt" we set this as active.
-                // Otherwise just pick the first type.
                 type: Object.keys(json).some(x => x === "courseevt")
                     ? "courseevt"
-                    : Object.keys(json)[0]
+                    : Object.keys(json)[0],
+                isLoading: false
             });
         });
     }
 
-    handleSelect() {
-        console.log("handleSelect()")
+    handleSelect(key) {
+        return (_, { value }) => {
+            this.setState({ [key]: value });
+        };
+    }
+
+    handleSubmit() {
+        fetch(
+            urlParams(window.injectedEnv.API_URL, "/api/config/template", {
+                name: this.props.name,
+                te_type: this.state.type,
+                te_fields: this.state.type
+            }),
+            {
+                method: "POST"
+            } // TODO: Does not work with "Content-Type" header added (CORS)
+        )
+            .then(resp => {
+                switch (resp.status) {
+                    case 204: // Success, no content
+                        // We don't adjust the state manually, instead we fetch a new
+                        // state from the server. Since we wait for the POST fetch
+                        // to complete, we know that the following GET will include our
+                        // new connection.
+                        this.context.refresh();
+                        this.props.setActive(false);
+                        break;
+                    case 404: // Already exists
+                    case 409:
+                        resp.json().then(json =>
+                            this.context.feedback(json.message)
+                        );
+                        break;
+                    default:
+                        throw new Error(
+                            `Unexpected HTTP response from backend: ${resp.status} ${resp.statusText}`
+                        );
+                }
+            })
+            .catch(e => console.error(e));
     }
 
     render() {
+        const { isLoading } = this.state;
+
         return (
-                <SimpleSelect
-                    renderLabel="Object Type"
-                    value={this.state.type}
-                    onChange={this.handleSelect("type")}
-                >
-                    {this.state.types.map(t => (
-                        <SimpleSelect.Option
-                            key={t.extid}
-                            id={t.extid}
-                            value={t.extid}
+            <>
+                {!isLoading ? (
+                    <>
+                        <div style={{ marginBottom: 10 }}>
+                            <SimpleSelect
+                                renderLabel="Object Type"
+                                value={this.state.type}
+                                onChange={this.handleSelect("type")}
+                            >
+                                {this.state.types.map(t => (
+                                    <SimpleSelect.Option
+                                        key={t.extid}
+                                        id={t.extid}
+                                        value={t.extid}
+                                    >
+                                        {t.title}
+                                    </SimpleSelect.Option>
+                                ))}
+                            </SimpleSelect>
+                        </div>
+                        <div margin={{ marginBottom: 10 }}>
+                            <SelectField
+                                type={this.state.type}
+                                onCancel={this.props.onCancel}
+                                onSubmit={this.handleSubmit}
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <Spinner renderTitle="Loading" />
+                )}
+            </>
+        );
+    }
+}
+
+class SelectField extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isLoading: true,
+            options: [],
+            isShowingOptions: false,
+            highlightedOptionId: null,
+            selectedOption: null
+        };
+        this.refresh = this.refresh.bind(this);
+        this.handleShowOptions = this.handleShowOptions.bind(this);
+        this.handleHideOptions = this.handleHideOptions.bind(this);
+        this.handleHighlightOption = this.handleHighlightOption.bind(this);
+        this.handleSelectOption = this.handleSelectOption.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
+    }
+
+    componentDidMount() {
+        if (this.props.type !== null) this.refresh();
+        console.log("refreshing te fields");
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.type !== prevProps.type) {
+            this.setState({ isLoading: true });
+            console.log("refreshing te fields");
+            this.refresh();
+        }
+    }
+    refresh() {
+        parseResponse(
+            fetch(
+                urlParams(window.injectedEnv.API_URL, "/api/timeedit/fields", {
+                    extid: this.props.type
+                })
+            ),
+            json => {
+                this.setState({
+                    options: json,
+                    isLoading: false,
+                    inputValue: json[0]
+                });
+            }
+        );
+    }
+
+    handleShowOptions() {
+        this.setState({
+            isShowingOptions: true
+        });
+    }
+
+    handleHideOptions() {
+        this.setState({
+            isShowingOptions: false,
+            highlightedOptionId: null
+        });
+    }
+
+    handleBlur() {
+        this.setState({ highlightedOptionId: null });
+    }
+
+    handleHighlightOption(event, { id }) {
+        event.persist();
+        this.setState({
+            selectedOptionId: id,
+            highlightedOptionId: id,
+            inputValue: id
+        });
+    }
+
+    handleSelectOption(_, { id }) {
+        this.setState({
+            selectedOptionId: id,
+            inputValue: id,
+            isShowingOptions: false
+        });
+        // this.props.setField(id);
+        console.log("setField", id);
+    }
+
+    render() {
+        const {
+            isLoading,
+            options,
+            inputValue,
+            isShowingOptions,
+            highlightedOptionId,
+            selectedOptionId
+        } = this.state;
+
+        return (
+            <>
+                {isLoading ? (
+                    <Spinner renderTitle="Loading" />
+                ) : (
+                    <>
+                        <Select
+                            renderLabel="Object Field"
+                            inputValue={inputValue}
+                            isShowingOptions={isShowingOptions}
+                            onBlur={this.handleBlur}
+                            onRequestShowOptions={this.handleShowOptions}
+                            onRequestHideOptions={this.handleHideOptions}
+                            onRequestHighlightOption={
+                                this.handleHighlightOption
+                            }
+                            onRequestSelectOption={this.handleSelectOption}
                         >
-                            {t.title}
-                        </SimpleSelect.Option>
-                    ))}
-                </SimpleSelect>
-        )
+                            {options.length > 0 ? (
+                                options.map(field => {
+                                    return (
+                                        <Select.Option
+                                            id={field}
+                                            key={field}
+                                            value={field}
+                                            isHighlighted={
+                                                field === highlightedOptionId
+                                            }
+                                            isSelected={
+                                                field === selectedOptionId
+                                            }
+                                        >
+                                            {field}
+                                        </Select.Option>
+                                    );
+                                })
+                            ) : (
+                                <Select.Option
+                                    id="empty-option"
+                                    key="empty-option"
+                                ></Select.Option>
+                            )}
+                        </Select>
+                        <div style={{ marginBottom: 10 }}>
+                            <Button
+                                margin="small"
+                                onClick={this.props.onSubmit}
+                            >
+                                Submit
+                            </Button>
+                            <Button onClick={this.props.onCancel}>
+                                Cancel
+                            </Button>
+                        </div>
+                    </>
+                )}
+            </>
+        );
     }
 }

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,8 +1,8 @@
 import React from "react";
 
-import { Button, Grid, GridCol, Heading, IconPlusLine, IconTrashLine, SimpleSelect, Tag, TextArea, TextInput, View } from "@instructure/ui";
+import { Button, Grid, GridCol, Heading, IconPlusLine, IconTrashLine, Modal, SimpleSelect, Tag, TextArea, TextInput, View } from "@instructure/ui";
 
-import { urlParams } from "../util";
+import { parseResponse, urlParams } from "../util";
 
 class Config extends React.Component {
     constructor(props) {
@@ -52,17 +52,17 @@ class Config extends React.Component {
         return (
             <div id="config">
                 <ConfigSection
-                    name="Title"
+                    name="title"
                     children={this.state.title}
                     onDelete={this.handleDelete}
                 />
                 <ConfigSection
-                    name="Location"
+                    name="location"
                     children={this.state.location}
                     onDelete={this.handleDelete}
                     />
                 <ConfigSection
-                    name="Description"
+                    name="description"
                     children={this.state.description}
                     onDelete={this.handleDelete}
                 />    
@@ -76,6 +76,9 @@ export default Config;
 class ConfigSection extends React.Component {
     constructor(props) {
         super(props)
+        this.state = {
+            addNew: false
+        }
     }
 
     render() {
@@ -91,30 +94,103 @@ class ConfigSection extends React.Component {
                     <Grid>
                         <Grid.Row>
                             <Grid.Col>
-                                <Heading level="h2">{this.props.name}</Heading>
+                                <Heading level="h2">{this.props.name.charAt(0).toUpperCase()}{this.props.name.slice(1)}</Heading>
                             </Grid.Col>
                             <Grid.Col width="auto">
-            <Button
-                renderIcon={IconPlusLine}
-                margin="small"
-                color="primary"
-            >
-                Add {this.props.name.toLowerCase()} field
-            </Button>
-
+                                <Button
+                                    renderIcon={IconPlusLine}
+                                    margin="small"
+                                    color="primary"
+                                    onClick={() => this.setState({ addNew: !this.state.addNew })}
+                                >
+                                    Add {this.props.name} field
+                                </Button>
                             </Grid.Col>
                         </Grid.Row>
-                    </Grid>
+                        <Grid.Row>
+                            <AddNew 
+                                type={this.props.name}
+                                active={this.state.addNew} />
+                        </Grid.Row>
             {this.props.children && this.props.children.map(c => 
-                <Button
-                    key={c.id}
-                    onClick={() => this.props.onDelete(c.id)}
-                    renderIcon={IconTrashLine}
-                    >
-                    <strong>{c.te_type}</strong> - {c.te_fields.join('.')}
-                </Button>
+                <Grid.Row>
+                    <Button
+                        key={c.id}
+                        onClick={() => this.props.onDelete(c.id)}
+                        renderIcon={IconTrashLine}>
+                        <strong>{c.te_type}</strong> - {c.te_fields.join('.')}
+                    </Button>
+                </Grid.Row>
                 )}
+                    </Grid>
                 </View>
 
     )}
+}
+
+class AddNew extends React.Component {
+    constructor(props) {
+        super(props)
+    }
+
+    render() {
+        return (
+            <div>
+            {this.props.active && <AddNewForm />}
+            </div>
+        )
+    }
+}
+
+class AddNewForm extends React.Component {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            types: []
+        }
+    }
+    
+    componentDidMount() {
+        let promise = fetch(
+            urlParams(window.injectedEnv.API_URL, "/api/timeedit/types", {})
+        );
+        parseResponse(promise, json => {
+            this.setState({
+                types: Object.entries(json).map(([k, v]) => ({
+                    extid: k,
+                    title: v
+                })),
+                // If the types include "courseevt" we set this as active.
+                // Otherwise just pick the first type.
+                type: Object.keys(json).some(x => x === "courseevt")
+                    ? "courseevt"
+                    : Object.keys(json)[0]
+            });
+        });
+    }
+
+    handleSelect() {
+        console.log("handleSelect()")
+    }
+
+    render() {
+        return (
+                <SimpleSelect
+                    renderLabel="Object Type"
+                    value={this.state.type}
+                    onChange={this.handleSelect("type")}
+                >
+                    {this.state.types.map(t => (
+                        <SimpleSelect.Option
+                            key={t.extid}
+                            id={t.extid}
+                            value={t.extid}
+                        >
+                            {t.title}
+                        </SimpleSelect.Option>
+                    ))}
+                </SimpleSelect>
+        )
+    }
 }

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Button, Heading, IconPlusLine, IconTrashLine, SimpleSelect, TextArea, TextInput, View } from "@instructure/ui";
+import { Button, Grid, GridCol, Heading, IconPlusLine, IconTrashLine, SimpleSelect, Tag, TextArea, TextInput, View } from "@instructure/ui";
 
 import { urlParams } from "../util";
 
@@ -13,6 +13,7 @@ class Config extends React.Component {
              description: []
         };
         this.refresh = this.refresh.bind(this);
+        this.handleDelete = this.handleDelete.bind(this);
     }
 
     componentDidMount() {
@@ -35,7 +36,6 @@ class Config extends React.Component {
     }
 
     handleDelete(id) {
-        console.log("delete",id)
         fetch(urlParams(window.injectedEnv.API_URL, "/api/config/template",{ id: id }),
         { method: "DELETE"}).then(resp => {
             if (resp.status !== 204)
@@ -51,76 +51,70 @@ class Config extends React.Component {
     render() {
         return (
             <div id="config">
-                <Heading level="h2">Title</Heading>
-                <View
-                display="block"
-                borderRadius="medium"
-                borderWidth="small"
-                background="secondary"
-                padding="medium"
-                margin="small"
-                >
-            <Button
-                renderIcon={IconPlusLine}
-                margin="small"
-                color="success"
-            >
-                Add title field
-            </Button>
-            {this.state.title && this.state.title.map(r => 
-                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
-                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
-                </Button>
-                )}
-                </View>
-                <Heading level="h2">Location</Heading>
-                <View
-                display="block"
-                borderRadius="medium"
-                borderWidth="small"
-                background="secondary"
-                padding="medium"
-                margin="small"
-                >
-            <Button
-                renderIcon={IconPlusLine}
-                margin="small"
-                color="success"
-            >
-                Add location field
-            </Button>
-            {this.state.location && this.state.location.map(r =>
-                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
-                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
-                </Button>
-                )}
-                </View>
-                <Heading level="h2">Description</Heading>
-
-                <View
-                display="block"
-                borderRadius="medium"
-                borderWidth="small"
-                background="secondary"
-                padding="medium"
-                margin="small"
-                >
-            <Button
-                renderIcon={IconPlusLine}
-                margin="small"
-                color="success"
-            >
-                Add description field
-            </Button>
-            {this.state.description && this.state.description.map(r => 
-                <Button key={r.id} renderIcon={IconTrashLine} onClick={() => this.handleDelete(r.id)} >
-                    <strong>{r.te_type}</strong> - {r.te_fields.join('.')}
-                </Button>
-            )}
-                </View>
+                <ConfigSection
+                    name="Title"
+                    children={this.state.title}
+                    onDelete={this.handleDelete}
+                />
+                <ConfigSection
+                    name="Location"
+                    children={this.state.location}
+                    onDelete={this.handleDelete}
+                    />
+                <ConfigSection
+                    name="Description"
+                    children={this.state.description}
+                    onDelete={this.handleDelete}
+                />    
             </div>
         );
     }
 }
 
 export default Config;
+
+class ConfigSection extends React.Component {
+    constructor(props) {
+        super(props)
+    }
+
+    render() {
+        return (
+                <View
+                display="block"
+                borderRadius="medium"
+                borderWidth="small"
+                background="secondary"
+                padding="medium"
+                margin="small"
+                >
+                    <Grid>
+                        <Grid.Row>
+                            <Grid.Col>
+                                <Heading level="h2">{this.props.name}</Heading>
+                            </Grid.Col>
+                            <Grid.Col width="auto">
+            <Button
+                renderIcon={IconPlusLine}
+                margin="small"
+                color="primary"
+            >
+                Add {this.props.name.toLowerCase()} field
+            </Button>
+
+                            </Grid.Col>
+                        </Grid.Row>
+                    </Grid>
+            {this.props.children && this.props.children.map(c => 
+                <Button
+                    key={c.id}
+                    onClick={() => this.props.onDelete(c.id)}
+                    renderIcon={IconTrashLine}
+                    >
+                    <strong>{c.te_type}</strong> - {c.te_fields.join('.')}
+                </Button>
+                )}
+                </View>
+
+    )}
+}

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -30,7 +30,13 @@ class Config extends React.Component {
     }
 
     refresh() {
-        fetch(urlParams(window.injectedEnv.API_URL, "/api/config/template"))
+        fetch(
+            urlParams(window.injectedEnv.API_URL, "/api/config/template", {
+                // MAGIC STRING ALERT: This key will be replaced on the Express
+                // side with LTI custom parameter `canvas_group`.
+                canvas_group: "LTI_CUSTOM_PROPERTY"
+            })
+        )
             .then(resp => {
                 if (resp.status !== 200)
                     throw new Error(

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -2,7 +2,6 @@ import React from "react";
 
 import {
     Button,
-    Grid,
     Heading,
     IconPlusLine,
     IconTrashLine,
@@ -110,7 +109,10 @@ class ConfigSection extends React.Component {
             urlParams(window.injectedEnv.API_URL, "/api/config/template", {
                 name: this.props.name,
                 te_type: type,
-                te_field: field
+                te_field: field,
+                // MAGIC STRING ALERT: This key will be replaced on the Express
+                // side with LTI custom parameter `canvas_group`.
+                canvas_group: "LTI_CUSTOM_PROPERTY"
             }),
             {
                 method: "POST"
@@ -133,6 +135,9 @@ class ConfigSection extends React.Component {
                 }
             })
             .catch(e => console.error(e));
+        this.setState({
+            addNew: false
+        });
     }
 
     render() {
@@ -170,6 +175,7 @@ class ConfigSection extends React.Component {
                         name={this.props.name}
                         onCancel={this.handleCancel}
                         onSubmit={this.handleSubmit}
+                        existingFields={Object.values(this.props.children)}
                     />
                 )}
                 {this.props.children &&
@@ -263,6 +269,7 @@ class AddNewField extends React.Component {
                                 type={this.state.type}
                                 onCancel={this.props.onCancel}
                                 onSubmit={this.handleSubmit}
+                                existingFields={this.props.existingFields}
                             />
                         </div>
                     </>
@@ -306,6 +313,7 @@ class SelectField extends React.Component {
             this.refresh();
         }
     }
+
     refresh() {
         parseResponse(
             fetch(
@@ -315,7 +323,9 @@ class SelectField extends React.Component {
             ),
             json => {
                 this.setState({
-                    options: json,
+                    options: json.filter(
+                        field => !this.props.existingFields.includes(field)
+                    ),
                     isLoading: false,
                     inputValue: json[0],
                     selectedOptionId: json[0]

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Button, TextArea, TextInput } from "@instructure/ui";
+import { Button, Heading, IconPlusLine, SimpleSelect, TextArea, TextInput, View } from "@instructure/ui";
 
 import { urlParams } from "../util";
 
@@ -8,9 +8,9 @@ class Config extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            title: "",
-            location: "",
-            description: ""
+             title: [],
+             location: [],
+             description: []
         };
 
         this.refresh = this.refresh.bind(this);
@@ -23,116 +23,105 @@ class Config extends React.Component {
     }
 
     refresh() {
-        for (let k of ["title", "location", "description"]) {
             fetch(
-                urlParams(window.injectedEnv.API_URL, "/api/config", {
-                    key: k
-                })
+                urlParams(window.injectedEnv.API_URL, "/api/config/template")
             )
                 .then(resp => {
                     if (resp.status !== 200)
                         throw new Error(
                             `Unexpected HTTP response from backend: ${resp.status}`
                         );
-                    return resp.text();
+                    return resp.json()
                 })
-                .then(v => {
-                    this.setState({ [k]: v });
-                });
-        }
+                .then(data => this.setState(data)
+            )
     }
 
     submit() {
-        for (let k of ["title", "location", "description"]) {
-            fetch(
-                urlParams(window.injectedEnv.API_URL, "/api/config", {
-                    key: k,
-                    value: this.state[k]
-                }),
-                {
-                    method: "PUT"
-                }
-            ).then(resp => {
-                if (resp.status !== 200)
-                    throw new Error(
-                        `Unexpected HTTP response from backend: ${resp.status}`
-                    );
-            });
-        }
+        // for (let k of ["title", "location", "description"]) {
+        //     fetch(
+        //         urlParams(window.injectedEnv.API_URL, "/api/config", {
+        //             key: k,
+        //             value: this.state[k]
+        //         }),
+        //         {
+        //             method: "PUT"
+        //         }
+        //     ).then(resp => {
+        //         if (resp.status !== 200)
+        //             throw new Error(
+        //                 `Unexpected HTTP response from backend: ${resp.status}`
+        //             );
+        //     });
+        // }
     }
 
     handleChange(k, v) {
-        this.setState({ [k]: v });
+        // this.setState({ [k]: v });
     }
 
     render() {
         return (
             <div id="config">
-                <KeyValue
-                    key_="title"
-                    label="Title"
-                    value={this.state.title}
-                    handleChange={this.handleChange}
-                />
-                <KeyValue
-                    key_="location"
-                    label="Location"
-                    value={this.state.location}
-                    handleChange={this.handleChange}
-                />
-                <KeyValue
-                    big={true}
-                    key_="description"
-                    label="Description"
-                    value={this.state.description}
-                    handleChange={this.handleChange}
-                />
+                <Heading level="h2">Title</Heading>
+                <View
+                display="block"
+                borderRadius="medium"
+                borderWidth="small"
+                background="secondary"
+                padding="medium"
+                margin="small"
+                >
+            <Button
+                renderIcon={IconPlusLine}
+                margin="small"
+                color="success"
+            >
+                Add title field
+            </Button>
+            {this.state.title && this.state.title.map(r => r.te_type)}
+                </View>
+                <Heading level="h2">Location</Heading>
+                <View
+                display="block"
+                borderRadius="medium"
+                borderWidth="small"
+                background="secondary"
+                padding="medium"
+                margin="small"
+                >
+            <Button
+                renderIcon={IconPlusLine}
+                margin="small"
+                color="success"
+            >
+                Add location field
+            </Button>
+            {this.state.location && this.state.location.map(r => r.te_type)}
+                </View>
+                <Heading level="h2">Description</Heading>
+
+                <View
+                display="block"
+                borderRadius="medium"
+                borderWidth="small"
+                background="secondary"
+                padding="medium"
+                margin="small"
+                >
+            <Button
+                renderIcon={IconPlusLine}
+                margin="small"
+                color="success"
+            >
+                Add description field
+            </Button>
+            {this.state.description && this.state.description.map(r => r.te_type)}
+                </View>
                 <Button onClick={this.submit}>Save and apply</Button>
                 &nbsp;
                 <Button onClick={this.refresh}>Discard edits</Button>
             </div>
-        );
-    }
-}
-
-class KeyValue extends React.Component {
-    render() {
-        return (
-            <div className="key-value">
-                {this.props.big ? (
-                    <BigKeyValue {...this.props} />
-                ) : (
-                    <SmallKeyValue {...this.props} />
-                )}
-            </div>
-        );
-    }
-}
-
-class SmallKeyValue extends React.Component {
-    render() {
-        return (
-            <TextInput
-                renderLabel={this.props.label}
-                value={this.props.value}
-                onChange={e =>
-                    this.props.handleChange(this.props.key_, e.target.value)
-                }
-            />
-        );
-    }
-}
-
-class BigKeyValue extends React.Component {
-    render() {
-        return (
-            <TextArea
-                label={this.props.label}
-                value={this.props.value}
-                onChange={e =>
-                    this.props.handleChange(this.props.key_, e.target.value)
-                }
-            />
         );
     }
 }

--- a/src/components/Sync.js
+++ b/src/components/Sync.js
@@ -3,7 +3,7 @@ import React from "react";
 import { Button, SimpleSelect, View } from "@instructure/ui";
 import { IconPlusLine, IconTrashLine } from "@instructure/ui-icons";
 
-import { MyContext, parseResponse, urlParams } from "../util";
+import { MyContext, createField, parseResponse, urlParams } from "../util";
 import AsyncSelect from "./AsyncSelect";
 import Feedback from "./Feedback";
 
@@ -73,8 +73,8 @@ class Sync extends React.Component {
                             .then(data => ({
                                 extid: data.extid,
                                 type: c.te_type, // TODO: Convert this to a type name using /api/timeedit/types
-                                id: this.createField(data, "id"),
-                                title: this.createField(data, "title")
+                                id: createField(data, "id"),
+                                title: createField(data, "title")
                             }))
                             .catch(e => {
                                 // This will lead Promise.all to also reject at
@@ -92,20 +92,6 @@ class Sync extends React.Component {
                 });
             })
             .catch(e => console.error(e)); // (2)
-    }
-
-    /**
-     * This function is needed since RKH use _ref suffix for id and title.
-     */
-    createField(objectToCreateFrom, type) {
-        let fieldToReturn = "";
-        if (objectToCreateFrom.hasOwnProperty('general.' + type)) {
-            fieldToReturn = objectToCreateFrom['general.' + type]
-        }
-        if (objectToCreateFrom.hasOwnProperty('general.' + type + '_ref')) {
-            fieldToReturn = objectToCreateFrom['general.' + type + '_ref']
-        }
-        return fieldToReturn
     }
 
     feedback(message) {

--- a/src/components/Sync.js
+++ b/src/components/Sync.js
@@ -234,7 +234,7 @@ class AddNew extends React.Component {
             <Button
                 renderIcon={IconPlusLine}
                 margin="small"
-                color="success"
+                color="primary"
                 onClick={() => this.setActive(true)}
             >
                 Add Object

--- a/src/components/Sync.js
+++ b/src/components/Sync.js
@@ -234,6 +234,7 @@ class AddNew extends React.Component {
             <Button
                 renderIcon={IconPlusLine}
                 margin="small"
+                color="success"
                 onClick={() => this.setActive(true)}
             >
                 Add Object

--- a/src/util.js
+++ b/src/util.js
@@ -31,3 +31,18 @@ export function urlParams(baseUrl, path, params) {
 }
 
 export let MyContext = React.createContext();
+
+/**
+ * This function is needed since RKH use _ref suffix for id and title.
+ * TODO: solve this backend
+ */
+export function createField(objectToCreateFrom, type) {
+    let fieldToReturn = "";
+    if (objectToCreateFrom.hasOwnProperty("general." + type)) {
+        fieldToReturn = objectToCreateFrom["general." + type];
+    }
+    if (objectToCreateFrom.hasOwnProperty("general." + type + "_ref")) {
+        fieldToReturn = objectToCreateFrom["general." + type + "_ref"];
+    }
+    return fieldToReturn;
+}


### PR DESCRIPTION
This PR will add support for interactive template config
we move from template strings to storing type-field mappings in db
the table has canvas_group column which could be used to move away from global template config
