### PR TITLE
fix: limit field count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "te-canvas-front",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "",
     "scripts": {
         "start": "API_URL=$LTI_URL ./make-inject-env.sh && DEBUG=provider:* node src/lti.js",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -43,13 +43,13 @@ class App extends React.Component {
                             renderTitle="Course Event Template"
                             isSelected={this.state.activeTab === 1}
                         >
-                            <Config default="false" />
+                            <Config default={false} />
                         </Tabs.Panel>
                         <Tabs.Panel
                             renderTitle="Default Event Template"
                             isSelected={this.state.activeTab === 2}
                         >
-                            <Config default="true" />
+                            <Config default={true} />
                         </Tabs.Panel>
                     </Tabs>
                 </div>

--- a/src/components/config/Config.js
+++ b/src/components/config/Config.js
@@ -61,6 +61,25 @@ class Config extends React.Component {
     render() {
         return (
             <>
+                {this.props.default ? (
+                    <p>
+                        This is <strong>default</strong> event template. It is
+                        used if an event template has not been configured for a
+                        course.
+                    </p>
+                ) : (
+                    <p>
+                        This is the event template{" "}
+                        <strong>for this course</strong>. If it is valid, it
+                        will be used instead of the default event template.
+                    </p>
+                )}
+                <p>
+                    Event template control what content the title, location and
+                    description fields in the canvas event will have. Thus, we
+                    create a template with the Timeedit object fields we want to
+                    use.
+                </p>
                 <ConfigSection
                     config_type="title"
                     default={this.props.default}

--- a/src/components/config/ConfigSection.js
+++ b/src/components/config/ConfigSection.js
@@ -9,6 +9,7 @@ import {
 } from "@instructure/ui";
 
 import { urlParams } from "../../util";
+import Feedback from "../Feedback";
 import AddFieldForm from "./AddFieldForm";
 
 class ConfigSection extends React.Component {
@@ -78,7 +79,7 @@ class ConfigSection extends React.Component {
                     {this.props.config_type.slice(1)}
                 </Heading>
                 <div>
-                    {!this.state.addNew && (
+                    {!this.state.addNew && this.props.children.length < 3 && (
                         <Button
                             renderIcon={IconPlusLine}
                             margin="small"
@@ -91,6 +92,12 @@ class ConfigSection extends React.Component {
                         >
                             Add {this.props.config_type} field
                         </Button>
+                    )}
+                    {this.props.children.length >= 3 && (
+                        <Feedback
+                            variant="info"
+                            message="Maximum field count reached."
+                        />
                     )}
                 </div>
                 {this.state.addNew && (


### PR DESCRIPTION
We limit field count per te_type to 3 because of a return type limit of 3 in Timeedit API.
Also add description to users and explain what event template is, and how course and default templates differ.