### PR TITLE
fix: be consistent with terminology

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import { urlParams } from "../util";
 import Feedback from "./Feedback";
 import Sync from "./Sync";
 import Config from "./config/Config";
-import WhitelistTypes from "./config/WhitelistTypes";
+import TimeeditTypeFilter from "./config/TimeeditTypeFilter";
 
 class App extends React.Component {
     constructor(props) {
@@ -53,10 +53,10 @@ class App extends React.Component {
                             <Config default={true} />
                         </Tabs.Panel>
                         <Tabs.Panel
-                            renderTitle="Whitelist types"
+                            renderTitle="TimeEdit Type Filter"
                             isSelected={this.state.activeTab === 3}
                         >
-                            <WhitelistTypes />
+                            <TimeeditTypeFilter />
                         </Tabs.Panel>
                     </Tabs>
                 </div>

--- a/src/components/config/Config.js
+++ b/src/components/config/Config.js
@@ -100,9 +100,7 @@ class Config extends React.Component {
                 )}
                 <p>
                     Event template control what content the title, location and
-                    description fields in the canvas event will have. Thus, we
-                    create a template with the Timeedit object fields we want to
-                    use.
+                    description fields in canvas events will have.
                 </p>
                 {this.state.isAdmin ? (
                     <>

--- a/src/components/config/TimeeditTypeFilter.js
+++ b/src/components/config/TimeeditTypeFilter.js
@@ -3,8 +3,9 @@ import React from "react";
 import { Checkbox, FormFieldGroup, Spinner } from "@instructure/ui";
 
 import { urlParams } from "../../util";
+import Feedback from "../Feedback";
 
-class WhitelistTypes extends React.Component {
+class TimeeditTypeFilter extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -31,7 +32,9 @@ class WhitelistTypes extends React.Component {
             .then(resp => {
                 if (resp.status === 403) {
                     this.setState({ isAdmin: false });
-                    throw new Error("User is unauthorized to update whitelist");
+                    throw new Error(
+                        "User is unauthorized to update TimeEdit type filter"
+                    );
                 }
                 if (resp.status !== 200 && resp.status !== 403)
                     throw new Error(
@@ -125,30 +128,41 @@ class WhitelistTypes extends React.Component {
     render() {
         return (
             <>
-                <p>
-                    This is a whitelist of which timeedit types we show when
-                    adding connections.
-                </p>
-                {this.state.types && this.state.whitelist ? (
-                    <FormFieldGroup>
-                        {this.state.types?.map(t => (
-                            <Checkbox
-                                size="small"
-                                variant="toggle"
-                                key={t.extid}
-                                value={t.extid}
-                                label={t.title}
-                                checked={this.state.whitelist.includes(t.extid)}
-                                onChange={this.handleToggle}
-                            />
-                        ))}
-                    </FormFieldGroup>
+                {this.state.isAdmin ? (
+                    <>
+                        <p>
+                            This is a filter of which TimeEdit types to show
+                            when adding Sync Objects.
+                        </p>
+                        {this.state.types && this.state.whitelist ? (
+                            <FormFieldGroup>
+                                {this.state.types?.map(t => (
+                                    <Checkbox
+                                        size="small"
+                                        variant="toggle"
+                                        key={t.extid}
+                                        value={t.extid}
+                                        label={t.title}
+                                        checked={this.state.whitelist.includes(
+                                            t.extid
+                                        )}
+                                        onChange={this.handleToggle}
+                                    />
+                                ))}
+                            </FormFieldGroup>
+                        ) : (
+                            <Spinner />
+                        )}
+                    </>
                 ) : (
-                    <Spinner />
+                    <Feedback
+                        variant="error"
+                        message="You must be a Canvas administrator to change TimeEdit type filter."
+                    />
                 )}
             </>
         );
     }
 }
 
-export default WhitelistTypes;
+export default TimeeditTypeFilter;


### PR DESCRIPTION
This PR makes the use of terminology more consistent in UI.
We also use "TimeEdit Type Filter" instead of "Whitelist".